### PR TITLE
Create basic Jekyll blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,29 @@
+# Jekyll configuration for the tech blog
+
+# Site settings
+title: DevOpsia Tech Blog
+description: "A blog about technology and software engineering."
+url: "" # Set to your GitHub Pages URL
+baseurl: "" # Subpath if needed
+
+# Build settings
+permalink: /:categories/:title/
+highlight:
+  style: monokai
+markdown: kramdown
+
+# Pagination
+paginate: 5
+paginate_path: "/page:num/"
+
+# Plugins
+plugins:
+  - jekyll-paginate
+  - jekyll-feed
+  - jekyll-seo-tag
+
+# Collections
+# default posts collection is enabled
+
+# Excerpts for index
+show_excerpts: true

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+  <p>&copy; {{ site.time | date: '%Y' }} {{ site.title }}. All rights reserved.</p>
+</footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,10 @@
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+    <nav class="site-nav">
+      <a href="{{ '/' | relative_url }}">Home</a>
+      <a href="{{ '/about' | relative_url }}">About</a>
+      <a href="{{ '/contact' | relative_url }}">Contact</a>
+    </nav>
+  </div>
+</header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  {%- feed_meta -%}
+  {%- seo -%}
+</head>
+<body>
+  {% include header.html %}
+  <main class="container">
+    {{ content }}
+  </main>
+  {% include footer.html %}
+</body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+
+<article class="post">
+  <h1>{{ page.title }}</h1>
+  <div class="post-meta">
+    <span class="date">{{ page.date | date: '%B %d, %Y' }}</span>
+    {% if page.tags %}
+    <span class="tags">{{ page.tags | join: ', ' }}</span>
+    {% endif %}
+  </div>
+  {{ content }}
+</article>

--- a/_posts/2024-01-01-welcome-to-my-blog.md
+++ b/_posts/2024-01-01-welcome-to-my-blog.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title: "Welcome to My Tech Blog"
+date: 2024-01-01 12:00:00 +0000
+tags: [intro]
+---
+
+This is the first post on my new Jekyll-powered tech blog. Here is a code snippet:
+
+```python
+print("Hello, World!")
+```
+
+You can also embed images and diagrams. Replace the image path with your own file:
+
+![Diagram placeholder](/assets/images/your-diagram.png)

--- a/about.md
+++ b/about.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: About
+---
+
+# About
+
+This is a sample about page. Write information about the blog or the author here.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,65 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #333;
+}
+
+.site-header {
+  background: #1e1e1e;
+  color: #fff;
+}
+
+.nav-container {
+  display: flex;
+  justify-content: space-between;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #fff;
+  text-decoration: none;
+}
+
+.site-nav a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+.container {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.post-meta {
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2rem;
+}
+
+.site-footer {
+  background: #f4f4f4;
+  text-align: center;
+  padding: 1rem;
+  margin-top: 2rem;
+}
+
+@media (max-width: 600px) {
+  .nav-container {
+    flex-direction: column;
+  }
+  .site-nav a {
+    margin: 0.5rem 0;
+  }
+}

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Contact
+---
+
+# Contact
+
+You can reach us at [email@example.com](mailto:email@example.com).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Home
+---
+
+<div class="posts">
+  {% for post in paginator.posts %}
+  <article class="post">
+    <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+    <div class="post-meta">
+      <span class="date">{{ post.date | date: "%B %d, %Y" }}</span>
+      {% if post.tags %}
+      <span class="tags">{{ post.tags | join: ", " }}</span>
+      {% endif %}
+    </div>
+    <div class="excerpt">
+      {{ post.excerpt }}
+    </div>
+  </article>
+  {% endfor %}
+</div>
+
+<div class="pagination">
+  {% if paginator.previous_page %}
+  <a href="{{ paginator.previous_page_path }}" class="prev">Prev</a>
+  {% endif %}
+  {% if paginator.next_page %}
+  <a href="{{ paginator.next_page_path }}" class="next">Next</a>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- set up Jekyll blog structure for GitHub Pages
- add default and post layouts
- add header and footer includes
- add CSS styling
- add example post and pages
- remove sample diagram image

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d11c9a5c4832f85ff464a61dd886d