### PR TITLE
Implement light theme layout with tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ highlight:
 markdown: kramdown
 
 # Pagination
-paginate: 5
+paginate: 6
 paginate_path: "/page:num/"
 
 # Plugins

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,9 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ page.title }} - {{ site.title }}</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <!-- Monospace font stack is defined in CSS -->
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   {%- feed_meta -%}
   {%- seo -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,9 +6,13 @@ layout: default
   <h1>{{ page.title }}</h1>
   <div class="post-meta">
     <span class="date">{{ page.date | date: '%B %d, %Y' }}</span>
-    {% if page.tags %}
-    <span class="tags">{{ page.tags | join: ', ' }}</span>
-    {% endif %}
   </div>
+  {% if page.tags %}
+  <div class="tags">
+    {% for tag in page.tags %}
+    <span class="tag">{{ tag }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
   {{ content }}
 </article>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,15 +1,15 @@
 body {
-  font-family: "Fira Sans", Arial, sans-serif;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   margin: 0;
   padding: 0;
-  color: #e0e0e0;
-  background: #121212;
+  color: #1f2937;
+  background: #ffffff;
   line-height: 1.6;
 }
 
 .site-header {
-  background: #1e1e1e;
-  color: #fff;
+  background: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
 }
 
 .nav-container {
@@ -23,14 +23,18 @@ body {
 .logo {
   font-size: 1.5rem;
   font-weight: bold;
-  color: #fff;
+  color: #1f2937;
   text-decoration: none;
 }
 
 .site-nav a {
-  color: #9ddcff;
+  color: #0366d6;
   margin-left: 1rem;
   text-decoration: none;
+}
+
+.site-nav a:hover {
+  text-decoration: underline;
 }
 
 .container {
@@ -39,9 +43,47 @@ body {
   padding: 0 1rem;
 }
 
+.posts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.post-card {
+  border: 1px solid #e5e7eb;
+  padding: 1rem;
+  background: #ffffff;
+  border-radius: 4px;
+}
+
+.post-card h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.post-card .excerpt {
+  margin-top: 0.5rem;
+}
+
 .post-meta {
   font-size: 0.9rem;
-  color: #a0a0a0;
+  color: #6b7280;
+  margin-bottom: 0.5rem;
+}
+
+.tags {
+  margin-top: 0.5rem;
+}
+
+.tag {
+  display: inline-block;
+  background: #f1f5f9;
+  border-radius: 9999px;
+  padding: 0.1rem 0.5rem;
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+  color: #1f2937;
 }
 
 .pagination {
@@ -51,9 +93,10 @@ body {
 }
 
 .site-footer {
-  background: #1e1e1e;
-  color: #e0e0e0;
+  background: #ffffff;
+  color: #6b7280;
   text-align: center;
+  border-top: 1px solid #e5e7eb;
   padding: 1rem;
   margin-top: 2rem;
 }

--- a/index.html
+++ b/index.html
@@ -3,26 +3,33 @@ layout: default
 title: Home
 ---
 
-<div class="posts">
+<div class="posts-grid">
   {% for post in paginator.posts %}
-  <article class="post">
+  <article class="post-card">
+    {% if post.thumbnail %}
+    <a href="{{ post.url }}"><img class="thumb" src="{{ post.thumbnail }}" alt="{{ post.title }} thumbnail"></a>
+    {% endif %}
     <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
     <div class="post-meta">
       <span class="date">{{ post.date | date: "%B %d, %Y" }}</span>
-      {% if post.tags %}
-      <span class="tags">{{ post.tags | join: ", " }}</span>
-      {% endif %}
     </div>
     <div class="excerpt">
       {{ post.excerpt }}
     </div>
+    {% if post.tags %}
+    <div class="tags">
+      {% for tag in post.tags %}
+      <span class="tag">{{ tag }}</span>
+      {% endfor %}
+    </div>
+    {% endif %}
   </article>
   {% endfor %}
 </div>
 
 <div class="pagination">
   {% if paginator.previous_page %}
-  <a href="{{ paginator.previous_page_path }}" class="prev">Prev</a>
+  <a href="{{ paginator.previous_page_path }}" class="prev">Previous</a>
   {% endif %}
   {% if paginator.next_page %}
   <a href="{{ paginator.next_page_path }}" class="next">Next</a>


### PR DESCRIPTION
## Summary
- update global light theme styles and grid layout
- switch pagination to 6 posts per page
- display tag badges on homepage and article pages

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5806c5a8832f891373212aaf6e0d